### PR TITLE
feat: add subscription price field to event schema

### DIFF
--- a/schemas/event.ts
+++ b/schemas/event.ts
@@ -30,6 +30,7 @@ export default {
         {
             name: "price",
             title: "Price",
+            description: "Price (free input)",
             type: "string",
         },
         {
@@ -90,7 +91,14 @@ export default {
             title: "Paid event",
             type: "boolean",
             description: "If checked, visitors will be asked to pay when subscribing",
-            hidden: true, // ({ document }: any) => !document.subscribable,
+            hidden: ({ document }: any) => !document.subscribable,
+        },
+        {
+            name: "subscriptionPrice",
+            title: "Price",
+            type: "number",
+            description: "Price in € (number)",
+            hidden: ({ document }: any) => !document.subscriptionIsPaid,
         },
         {
             name: "confirmationMailSubject",


### PR DESCRIPTION
- Add subscriptionPrice field for numeric price input
- Update field visibility logic to show price field only for paid events
- Improve field descriptions for better UX

🤖 Generated with [Claude Code](https://claude.ai/code)